### PR TITLE
Add implicit destructor and prefer `scoped*` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Playspace::scoped(|space| {
 
     // Run some command that needs these resources...
 
-}).expect("Failed to create playspace");
+}).expect("Failed to create or destroy playspace");
 
 // Now your environment is back where we started
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -627,7 +627,7 @@ impl Playspace {
     }
 
     fn restore_directory(saved_current_dir: Option<PathBuf>) -> Result<(), std::io::Error> {
-        if let Some(working_dir) = saved_current_dir.take() {
+        if let Some(working_dir) = saved_current_dir {
             std::env::set_current_dir(working_dir)
         } else {
             Err(std::io::Error::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -744,7 +744,7 @@ impl Playspace {
         I: IntoIterator<Item = (K, Option<V>)>,
         K: AsRef<OsStr>,
         V: AsRef<OsStr>,
-        F: FnOnce(&mut Self) -> R,
+        F: for<'a> FnOnce(&'a mut Self) -> Pin<Box<dyn Future<Output = R> + 'a>>,
     {
         let mut space = Self::with_envs_async(vars).await?;
         let out = f(&mut space).await;


### PR DESCRIPTION
Add an explicit destructor: `.exit()` to report errors while exiting Playspace.

Strongly prefer `scoped*` methods since they automatically use this destructor. Document that RAII use should use this destructor.